### PR TITLE
added html reporting by default. closes #6

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -32,16 +32,22 @@ var runCmd = &cobra.Command{
 			if args == nil {
 				args = []string{}
 			}
-			imagePath := internal.CaptureWindow(logger, getOutputPath(), step.Command, args, strconv.Itoa(idx))
+			imagePath := internal.CaptureWindow(logger, getOutputPath(), step.Command, args, strconv.Itoa(idx), ".jpg")
 			if step.Label != "" {
 				internal.AddLabelToImage(logger, step.Label, imagePath)
 			}
 			if step.Description != "" {
 				internal.AddDescriptionToImage(logger, step.Description, imagePath)
 			}
+			clingyData.Steps[idx].ImageOutput = fmt.Sprintf("%s%s", strconv.Itoa(idx), ".jpg")
 		}
 
 		internal.ClearTerminal()
-		fmt.Println("Completed clingy run.")
+		fmt.Println("Completed clingy run, generating report.")
+
+		if err := internal.GenerateHTMLReport(logger, clingyData, fmt.Sprintf("%s/index.html", getOutputPath())); err != nil {
+			fmt.Println("Error in generating report")
+			os.Exit(1)
+		}
 	},
 }

--- a/internal/magick.go
+++ b/internal/magick.go
@@ -16,17 +16,18 @@ func CaptureWindow(
 	command string,
 	commandArgs []string,
 	screenshotName string,
+	screenshotExtension string,
 ) string {
 	// typical execution path - magick import -window $WINDOWID ./images/{screenshot}
 	logger.Println("Taking screenshot", fmt.Sprintf("WINDOWID - %s", os.Getenv("WINDOWID")))
-	expectedPath := fmt.Sprintf("%s/%s.jpg", buildDirectory, screenshotName)
+	expectedPath := fmt.Sprintf("%s/%s%s", buildDirectory, screenshotName, screenshotExtension)
 	logger.Println("Saving to path", expectedPath)
 
 	fmt.Println("> ", command, strings.Join(commandArgs, " "))
 	output, _ := exec.Command(command, commandArgs...).CombinedOutput() // always allow the command to possibly error
 	fmt.Println(string(output))
 	logger.Println("Finished executing command", command)
-	time.Sleep(1000 * time.Millisecond) // waiting because the parent terminal process may not have finished rendering
+	time.Sleep(200 * time.Millisecond) // waiting because the parent terminal process may not have finished rendering
 
 	imageCommand := exec.Command(
 		"magick",

--- a/internal/report.go
+++ b/internal/report.go
@@ -1,0 +1,51 @@
+package internal
+
+import (
+	"embed"
+	"html/template"
+	"log"
+	"os"
+
+	"clingy/lib"
+)
+
+//go:embed templates
+var templates embed.FS
+
+// GenerateHTMLReport - generate a HTML report by reading from a file and writing to a specified destination
+func GenerateHTMLReport(logger *log.Logger, data *lib.ClingyTemplate, outFile string) error {
+	logger.Println("Generating HTML report", data.Label, outFile)
+
+	inputTemplateBytes, err := templates.ReadFile("templates/simple-report.template.html")
+	if err != nil {
+		logger.Println("Error in reading embed template", err)
+		return err
+	}
+
+	inputTemplate, err := template.New("report").Parse(string(inputTemplateBytes))
+	if err != nil {
+		logger.Println("Error in creating template from templatedir", err)
+		return err
+	}
+
+	out, err := os.Create(outFile)
+	if err != nil {
+		logger.Println("Error in creating outfile", outFile, err)
+		return err
+	}
+	defer func(out *os.File) {
+		err = out.Close()
+		if err != nil {
+			logger.Println("Error in closing outFile", outFile, err)
+			// unable to safely return in closure/defer func
+		}
+	}(out)
+
+	if err = inputTemplate.ExecuteTemplate(out, "report", data); err != nil {
+		logger.Println("Error in executing on template", err)
+		return err
+	}
+
+	logger.Println("Completed generating HTML report", data.Label, outFile)
+	return nil
+}

--- a/internal/templates/simple-report.template.html
+++ b/internal/templates/simple-report.template.html
@@ -1,0 +1,27 @@
+<html lang="en">
+<head><title>Clingy Report - {{.Label}}</title></head>
+<link rel="stylesheet" href="https://unpkg.com/@picocss/pico@latest/css/pico.min.css">
+<body>
+<hgroup>
+    <h1>
+        Clingy Report - {{.Label}}
+    </h1>
+    <h2>
+        Steps:
+    </h2>
+</hgroup>
+{{range $idx, $step := .Steps}}
+<div>
+    <hgroup>
+        <h3>
+            #{{$idx}} {{$step.Label}}
+        </h3>
+        <h4>
+            {{$step.Description}}
+        </h4>
+    </hgroup>
+    <img alt="screenshot of {{$step.Label}}" src="{{$step.ImageOutput}}" />
+</div>
+{{end}}
+</body>
+</html>

--- a/lib/models.go
+++ b/lib/models.go
@@ -6,6 +6,7 @@ type ClingyStep struct {
 	Description string   `yaml:"description"`
 	Command     string   `yaml:"command"`
 	Args        []string `yaml:"args"`
+	ImageOutput string
 }
 
 // ClingyTemplate - a full set of clingy instruction to follow


### PR DESCRIPTION
Currently generates a report as anticipated:

![image](https://user-images.githubusercontent.com/2961973/179510600-7b400e3d-d5e4-41da-9f56-0f02cf19d021.png)
